### PR TITLE
Add github standard Go gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,30 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
 .DS_Store
 bin
 pkg
+
+*.swp


### PR DESCRIPTION
git was wanting to add my vim .swp files, so I've updated the .gitignore to use GitHub defaults in addition to ignoring vim *.swp files
